### PR TITLE
feature: docker compose example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+.idea

--- a/example/Dockerfile-Directus
+++ b/example/Dockerfile-Directus
@@ -1,0 +1,13 @@
+# v11.4.0 runs on node 22, which is incompatible with isolated-vm in directus-extension-search-engine
+FROM directus/directus:11.3.5
+
+USER root
+
+RUN corepack enable
+
+# Install python to compile directus-extension-search-engine
+RUN apk add python3 make g++
+
+USER node
+
+RUN pnpm install directus-extension-search-engine

--- a/example/Readme.md
+++ b/example/Readme.md
@@ -36,13 +36,12 @@ Typesense Schema:
 ``` javascript
 module.exports = function(data) {
     const escapeHtml = (text) => text ? text.replace(/(<([^>]+)>)/gi, '') : text;
-	console.log(data)
     return data.map(item => ({
         id: item.id.toString(),
         email: item.email,
         first_name: item.first_name,
         last_name: item.last_name,
-        role: item.role.name,
+        role: item.role ? item.role.name : null
     }));
 };
 ```

--- a/example/Readme.md
+++ b/example/Readme.md
@@ -60,11 +60,13 @@ module.exports = function(data) {
         },
         {
             "name": "first_name",
-            "type": "string"
+            "type": "string",
+            "optional": true
         },
         {
             "name": "last_name",
-            "type": "string"
+            "type": "string",
+            "optional": true
         },
         {
             "name": "role",

--- a/example/Readme.md
+++ b/example/Readme.md
@@ -1,0 +1,82 @@
+## Directus with Typesense
+
+### 1. Run stack
+``` bash
+docker-compose up -d
+```
+
+### 2. Access Directus at http://localhost:8055
+Login with: admin@axample.com / admin
+
+### 3. Create a new entry in "Search Engine Configs" Collection
+**Hint: Save both "Search Engine Configs" Collection and "Typesense Schema" Item and to sync typesense**
+
+Engine Types: Typesense
+
+Typesense URLs: http://typesense:8108
+
+Typesense Schema:
+- Status: Published
+- Schema Name: users
+- Collection: directus_users
+- Mode: Trigger Event
+- Query:
+``` json
+{
+    "fields": [
+        "id",
+        "email",
+        "first_name",
+        "last_name",
+        "role.name"
+    ]
+}
+```
+- Function Parse:
+``` javascript
+module.exports = function(data) {
+    const escapeHtml = (text) => text ? text.replace(/(<([^>]+)>)/gi, '') : text;
+	console.log(data)
+    return data.map(item => ({
+        id: item.id.toString(),
+        email: item.email,
+        first_name: item.first_name,
+        last_name: item.last_name,
+        role: item.role.name,
+    }));
+};
+```
+- Schema:
+``` json
+{
+    "fields": [
+        {
+            "name": "id",
+            "type": "string"
+        },
+        {
+            "name": "email",
+            "type": "string"
+        },
+        {
+            "name": "first_name",
+            "type": "string"
+        },
+        {
+            "name": "last_name",
+            "type": "string"
+        },
+        {
+            "name": "role",
+            "type": "string",
+            "optional": true
+        }
+    ],
+    "token_separators": [
+        "+",
+        "-",
+        "@",
+        "."
+    ]
+}
+```

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -1,0 +1,68 @@
+services:
+
+  directus:
+    build:
+      dockerfile: Dockerfile-Directus
+    container_name: directus
+    ports:
+      - '8055:8055'
+    depends_on:
+      directus-postgres:
+        condition: service_healthy
+      typesense:
+        condition: service_healthy
+    environment:
+      LOG_LEVEL: 'trace'
+      TELEMETRY: 'false'
+      KEY: 'none'
+      SECRET: 'none'
+      DB_CLIENT: 'pg'
+      DB_HOST: 'directus-postgres'
+      DB_PORT: '5432'
+      DB_DATABASE: 'directus'
+      DB_USER: 'directus'
+      DB_PASSWORD: 'directus'
+      CACHE_ENABLED: 'false'
+      ADMIN_EMAIL: 'admin@example.com'
+      ADMIN_PASSWORD: 'admin'
+      PUBLIC_URL: 'http://localhost:8055'
+      MAX_PAYLOAD_SIZE: '10mb'
+      TYPESENSE_API_KEY: 'random-api-key'
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://directus:8055/server/health || exit 1
+      start_period: 15s
+      interval: 5s
+      timeout: 5s
+      retries: 25
+
+  directus-postgres:
+    image: postgres
+    container_name: directus-postgres
+    ports:
+      - '5432:5432' # mapped to be accessible via ide
+    environment:
+      POSTGRES_USER: directus
+      POSTGRES_PASSWORD: directus
+      POSTGRES_DB: directus
+    healthcheck:
+      test: pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  typesense:
+    image: typesense/typesense:27.0
+    container_name: typesense
+    restart: on-failure
+    ports:
+      - "8108:8108"
+    environment:
+      TYPESENSE_API_KEY: random-api-key
+      TYPESENSE_DATA_DIR: /tmp
+      TYPESENSE_ENABLE_CORS: "true"
+    healthcheck:
+      test: ["CMD-SHELL", "apt install curl -y &>/dev/null || curl --silent --fail localhost:8108/health || exit 1"]
+      start_period: 15s
+      interval: 30s
+      timeout: 5s
+      retries: 15

--- a/example/typesense.http
+++ b/example/typesense.http
@@ -1,0 +1,9 @@
+### Get all collections
+GET http://localhost:8108/collections
+X-TYPESENSE-API-KEY: random-api-key
+Content-Type: application/json
+
+### Search all users
+GET http://localhost:8108/collections/users/documents/search?q=*
+X-TYPESENSE-API-KEY: random-api-key
+Content-Type: application/json


### PR DESCRIPTION
# Docker Compose Example

| Status  | Type  | Env Vars Change | Review App | Ticket |
| :---: | :---: | :---: | :--: | :--: |
| Ready | Feature | No |  |  |

## Problem

Getting Started was kinda hard, since there were some issues installing the plugin within directus.


## Solution

I set up a Dockerfile-Directus in which installs the plugin. 
The resulting image is used within a docker-compose.yaml

Additionally i described how to sync directus_users to typesense.


## Additional Notes

The current version of the plugin is not compatible with the latest directus version, since virtual-vm is not compatible with node 22.
